### PR TITLE
useLegacySql flag support

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -593,10 +593,12 @@ module Google
         # @!group Data
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, large_results: nil, flatten: nil
+                      create: nil, write: nil, large_results: nil, flatten: nil,
+                      use_legacy_sql: true
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
-                      large_results: large_results, flatten: flatten }
+                      large_results: large_results, flatten: flatten,
+                      use_legacy_sql: use_legacy_sql }
           options[:dataset] ||= self
           ensure_service!
           gapi = service.query_job query, options

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -156,12 +156,12 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil
+                      dataset: nil, use_legacy_sql: true
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      dataset: dataset }
+                      dataset: dataset, use_legacy_sql: use_legacy_sql }
           gapi = service.query_job query, options
           Job.from_gapi gapi, service
         end
@@ -228,10 +228,11 @@ module Google
         #   end
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil
+                  dataset: nil, project: nil, use_legacy_sql: true
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
-                      dataset: dataset, project: project }
+                      dataset: dataset, project: project,
+                      use_legacy_sql: use_legacy_sql }
           gapi = service.query query, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -99,6 +99,14 @@ module Google
         end
 
         ##
+        # Checks if the query job is using legacy SQL.
+        def use_legacy_sql?
+          value = config['query']['useLegacySql']
+          return true if value.nil?
+          value
+        end
+
+        ##
         # Retrieves the query results for the job.
         #
         # @param [String] token Page token, returned by a previous call,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -397,7 +397,8 @@ module Google
                 write_disposition: write_disposition(options[:write]),
                 allow_large_results: options[:large_results],
                 flatten_results: options[:flatten],
-                default_dataset: default_dataset
+                default_dataset: default_dataset,
+                use_legacy_sql: options[:use_legacy_sql]
               )
             )
           )

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "0.20.1"
+      VERSION = "0.20.1.tj1"
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
@@ -200,7 +200,8 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
       "priority" => "BATCH",
       "allowLargeResults" => true,
       "useQueryCache" => true,
-      "flattenResults" => true
+      "flattenResults" => true,
+      "useLegacySql" => true
     }
     hash
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -45,6 +45,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.must_be :large_results?
     job.must_be :cache?
     job.must_be :flatten?
+    job.must_be :use_legacy_sql?
   end
 
   it "knows its statistics data" do
@@ -82,7 +83,8 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
       "priority" => "BATCH",
       "allowLargeResults" => true,
       "useQueryCache" => true,
-      "flattenResults" => true
+      "flattenResults" => true,
+      "useLegacySql" => true
     }
     hash["statistics"]["query"] = {
       "cacheHit" => false,

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -328,7 +328,8 @@ class MockBigquery < Minitest::Spec
           "priority" => "INTERACTIVE",
           "allowLargeResults" => nil,
           "useQueryCache" => true,
-          "flattenResults" => nil
+          "flattenResults" => nil,
+          "useLegacySql" => true
         }
       }
     }.to_json


### PR DESCRIPTION
This _may_ be required for https://github.com/Tapjoy/insights_service/pull/116. If the feature isn't GA and support added to the official gem by Monday, October 2nd we will use this fork until the feature is officially available.

Based on https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/720, conflicts necessitated rewriting.
