### PR TITLE
Respect use_legacy_sql everywhere

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -653,8 +653,10 @@ module Google
         #
         # @!group Data
         #
-        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true
-          options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache }
+        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
+                         use_legacy_sql: true
+          options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
+                      use_legacy_sql: use_legacy_sql }
           options[:dataset] ||= dataset_id
           options[:project] ||= project_id
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -413,7 +413,8 @@ module Google
             default_dataset: dataset_config,
             timeout_ms: options[:timeout],
             dry_run: options[:dryrun],
-            use_query_cache: options[:cache]
+            use_query_cache: options[:cache],
+            use_legacy_sql: options[:use_legacy_sql]
           )
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "0.20.1.tj1"
+      VERSION = "0.20.1.tj2"
     end
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -374,7 +374,7 @@ module Google
         def data max: nil, timeout: 10000, cache: true, dryrun: nil
           sql = "SELECT * FROM #{query_id}"
           ensure_service!
-          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun }
+          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun, use_legacy_sql: true }
           gapi = service.query sql, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -344,7 +344,8 @@ class MockBigquery < Minitest::Spec
       max_results: nil,
       query: "SELECT name, age, score, active FROM [some_project:some_dataset.users]",
       timeout_ms: 10000,
-      use_query_cache: true
+      use_query_cache: true,
+      use_legacy_sql: true
     )
   end
 


### PR DESCRIPTION
Original PR did not cover all cases! This should do it (tested a few queries against a public dataset switching between modes).
